### PR TITLE
Add: Initial Test Topic Creation to Docker-Compose, Update: Couchbase Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,10 @@ services:
       - 9092:9092
       - 28082:28082
       - 29092:29092
+  redpanda-topic-create:
+    image: docker.redpanda.com/redpandadata/redpanda
+    container_name: redpanda-topic-create
+    entrypoint: [ "bash", "-c", "sleep 5 && rpk topic create test --brokers redpanda:29092" ]
+    depends_on:
+      - redpanda
+    restart: "no"

--- a/test/couchbase/Dockerfile
+++ b/test/couchbase/Dockerfile
@@ -1,5 +1,5 @@
 #FROM couchbase/server:community-7.1.0-aarch64
-FROM couchbase:community-7.1.0
+FROM couchbase:community-7.2.2
 
 ADD configure.sh /configure.sh
 RUN chmod +x /configure.sh


### PR DESCRIPTION
- Initial topic creation at docker-compose to make things easier
- `couchbase:community-7.1.0` wasn't pulling from dockerhub so updated that to `couchbase:community-7.2.2` see below:

` ERROR [internal] load metadata for docker.io/library/couchbase:community-7.1.0                                                                                         1.8s
------
 > [internal] load metadata for docker.io/library/couchbase:community-7.1.0:
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: no match for platform in manifest sha256:c5a18e2523c0df3f33cf628951ca40eeeb770d18c1b6bd5c40cc306f756b2136: not found
`