### PR TITLE
feat: add mapstructure name tag support to config struct for viper dy…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,8 @@ func (k *Kafka) GetCompression() int8 {
 }
 
 type Connector struct {
-	Kafka Kafka      `yaml:"kafka"`
-	Dcp   config.Dcp `yaml:",inline"`
+	Kafka Kafka      `yaml:"kafka" mapstructure:"kafka"`
+	Dcp   config.Dcp `yaml:",inline" mapstructure:",squash"`
 }
 
 func (c *Connector) ApplyDefaults() {


### PR DESCRIPTION
With mapstructure name tags in config struct, viper package will be able to parse inline config.
Closes #69  