### PR TITLE
feature: add callback function after the event is published

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -1,0 +1,14 @@
+package dcpkafka
+
+import "github.com/Trendyol/go-dcp-kafka/kafka/message"
+
+type callback struct {
+}
+
+func (c *callback) OnSuccess(message message.KafkaMessage) {
+
+}
+
+func (c *callback) OnError(message message.KafkaMessage) {
+
+}

--- a/example/README.md
+++ b/example/README.md
@@ -39,7 +39,19 @@ func mapper(event couchbase.Event) []message.KafkaMessage {
 }
 ```
 
-## Step 3: Configuring the Connector
+## Step 3: Implementing the Callback Func
+
+This function is called after the event is published and takes `message.KafkaMessage` as a parameter.
+Here's an example callback implementation:
+
+```go
+func callback(msg message.KafkaMessage) {
+	// the code you want to run after an event is published
+	fmt.Printf("%v\n", msg.Key)
+}
+```
+
+## Step 4: Configuring the Connector
 
 The configuration for the connector is provided via a YAML file. Here's an example [configuration](https://github.com/Trendyol/go-dcp-kafka/blob/master/example/config.yml):
 
@@ -47,13 +59,17 @@ You can find explanation of [configurations](https://github.com/Trendyol/go-dcp#
 
 You can pass this configuration file to the connector by providing the path to the file when creating the connector:
 ```go
-connector, err := dcpkafka.NewConnector("path-to-config.yml", mapper)
+connector, err := dcpkafka.NewConnectorBuilder("config.yml").
+    SetMapper(mapper).
+    SetCallback(callback). // if you want to add callback func
+    Build()
+
 if err != nil {
 panic(err)
 }
 ```
 
-## Step 4: Starting and Closing the Connector
+## Step 5: Starting and Closing the Connector
 
 Once you have implemented the mapper and configured the connector, you can start/stop the connector:
 

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"github.com/Trendyol/go-dcp-kafka"
+	"fmt"
+	dcpkafka "github.com/Trendyol/go-dcp-kafka"
 	"github.com/Trendyol/go-dcp-kafka/couchbase"
 	"github.com/Trendyol/go-dcp-kafka/kafka/message"
 )
@@ -17,8 +18,21 @@ func mapper(event couchbase.Event) []message.KafkaMessage {
 	}
 }
 
+type callback struct{}
+
+func (c *callback) OnSuccess(message message.KafkaMessage) {
+	fmt.Printf("OnSuccess %v\n", string(message.Value))
+}
+
+func (c *callback) OnError(message message.KafkaMessage) {
+	fmt.Printf("OnError %v\n", string(message.Value))
+}
+
 func main() {
-	c, err := dcpkafka.NewConnectorBuilder("config.yml").SetMapper(mapper).Build()
+	c, err := dcpkafka.NewConnectorBuilder("config.yml").
+		SetMapper(mapper).
+		SetCallback(&callback{}). // if you want to add callback func
+		Build()
 	if err != nil {
 		panic(err)
 	}

--- a/kafka/producer/producer.go
+++ b/kafka/producer/producer.go
@@ -1,6 +1,7 @@
 package producer
 
 import (
+	"github.com/Trendyol/go-dcp-kafka/kafka/message"
 	"time"
 
 	"github.com/Trendyol/go-dcp/helpers"
@@ -20,9 +21,15 @@ type Producer struct {
 	ProducerBatch *Batch
 }
 
+type Callback interface {
+	OnSuccess(message message.KafkaMessage)
+	OnError(message message.KafkaMessage)
+}
+
 func NewProducer(kafkaClient gKafka.Client,
 	config *config.Connector,
 	dcpCheckpointCommit func(),
+	callback Callback,
 ) (Producer, error) {
 	writer := kafkaClient.Producer()
 
@@ -33,6 +40,7 @@ func NewProducer(kafkaClient gKafka.Client,
 			config.Kafka.ProducerBatchSize,
 			int64(helpers.ResolveUnionIntOrStringValue(config.Kafka.ProducerBatchBytes)),
 			dcpCheckpointCommit,
+			callback,
 		),
 	}, nil
 }


### PR DESCRIPTION
For Kafka events in our outbox bucket, we want to use go-dcp-kafka to send them. When event is published,  we want to remove the event document from the outbox bucket. #77 

For this reason, I made a development to add a callback function after the event is published