### PR TITLE
feature: add sinkResponseHandler

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -39,7 +39,25 @@ func mapper(event couchbase.Event) []message.KafkaMessage {
 }
 ```
 
-## Step 3: Configuring the Connector
+## Step 3: Implementing the SinkResponseHandler
+
+This function is called after the event is published and takes `message.KafkaMessage` as a parameter.
+Here's an example SinkResponseHandler implementation:
+
+```go
+type sinkResponseHandler struct {
+}
+
+func (s *sinkResponseHandler) OnSuccess(ctx *kafka.SinkResponseHandlerContext) {
+fmt.Printf("OnSuccess %v\n", string(ctx.Message.Value))
+}
+
+func (s *sinkResponseHandler) OnError(ctx *kafka.SinkResponseHandlerContext) {
+fmt.Printf("OnError %v\n", string(ctx.Message.Value))
+}
+```
+
+## Step 4: Configuring the Connector
 
 The configuration for the connector is provided via a YAML file. Here's an example [configuration](https://github.com/Trendyol/go-dcp-kafka/blob/master/example/config.yml):
 
@@ -47,13 +65,17 @@ You can find explanation of [configurations](https://github.com/Trendyol/go-dcp#
 
 You can pass this configuration file to the connector by providing the path to the file when creating the connector:
 ```go
-connector, err := dcpkafka.NewConnector("path-to-config.yml", mapper)
+connector, err := dcpkafka.NewConnectorBuilder("config.yml").
+    SetMapper(mapper).
+	SetSinkResponseHandler(&sinkResponseHandler{}). // if you want to add callback func
+    Build()
+
 if err != nil {
-panic(err)
+	panic(err)
 }
 ```
 
-## Step 4: Starting and Closing the Connector
+## Step 5: Starting and Closing the Connector
 
 Once you have implemented the mapper and configured the connector, you can start/stop the connector:
 

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/Trendyol/go-dcp-kafka"
+	"fmt"
+	dcpkafka "github.com/Trendyol/go-dcp-kafka"
 	"github.com/Trendyol/go-dcp-kafka/couchbase"
+	"github.com/Trendyol/go-dcp-kafka/kafka"
 	"github.com/Trendyol/go-dcp-kafka/kafka/message"
 )
 
@@ -17,8 +19,22 @@ func mapper(event couchbase.Event) []message.KafkaMessage {
 	}
 }
 
+type sinkResponseHandler struct {
+}
+
+func (s *sinkResponseHandler) OnSuccess(ctx *kafka.SinkResponseHandlerContext) {
+	fmt.Printf("OnSuccess %v\n", string(ctx.Message.Value))
+}
+
+func (s *sinkResponseHandler) OnError(ctx *kafka.SinkResponseHandlerContext) {
+	fmt.Printf("OnError %v\n", string(ctx.Message.Value))
+}
+
 func main() {
-	c, err := dcpkafka.NewConnectorBuilder("config.yml").SetMapper(mapper).Build()
+	c, err := dcpkafka.NewConnectorBuilder("config.yml").
+		SetMapper(mapper).
+		SetSinkResponseHandler(&sinkResponseHandler{}).
+		Build()
 	if err != nil {
 		panic(err)
 	}

--- a/kafka/producer/producer.go
+++ b/kafka/producer/producer.go
@@ -23,6 +23,7 @@ type Producer struct {
 func NewProducer(kafkaClient gKafka.Client,
 	config *config.Connector,
 	dcpCheckpointCommit func(),
+	sinkResponseHandler gKafka.SinkResponseHandler,
 ) (Producer, error) {
 	writer := kafkaClient.Producer()
 
@@ -33,6 +34,7 @@ func NewProducer(kafkaClient gKafka.Client,
 			config.Kafka.ProducerBatchSize,
 			int64(helpers.ResolveUnionIntOrStringValue(config.Kafka.ProducerBatchBytes)),
 			dcpCheckpointCommit,
+			sinkResponseHandler,
 		),
 	}, nil
 }

--- a/kafka/sink_response_handler.go
+++ b/kafka/sink_response_handler.go
@@ -1,0 +1,15 @@
+package kafka
+
+import (
+	"github.com/Trendyol/go-dcp-kafka/kafka/message"
+)
+
+type SinkResponseHandlerContext struct {
+	Message *message.KafkaMessage
+	Err     error
+}
+
+type SinkResponseHandler interface {
+	OnSuccess(ctx *SinkResponseHandlerContext)
+	OnError(ctx *SinkResponseHandlerContext)
+}


### PR DESCRIPTION
For Kafka events in our outbox bucket, we want to use go-dcp-kafka to send them. When event is published, we want to remove the event document from the outbox bucket. https://github.com/Trendyol/go-dcp-kafka/issues/77

For this reason, I made a development sinkResponseHandler to handle the function after the event is published or failed.